### PR TITLE
Update nbpCore.php

### DIFF
--- a/classes/nbpCore.php
+++ b/classes/nbpCore.php
@@ -191,7 +191,7 @@ class nbpCore
         }
             
         $this->main->getElements();
-        $this->render = new nbpRender($this->app->nbp_options_appearance + $this->main->nbp_options_main, $this->pluginPath, $this->getPluginVer());
+        $this->render = new nbpRender($this->app->nbp_options_appearance + $this->main->nbp_options_main, $this->pluginPathFull, $this->getPluginVer());
         $this->render->doTheMagic();
         
         if($this->flag_app_update == 1 || $this->flag_main_update == 1)


### PR DESCRIPTION
We were seeing the plugin make 13 connections to itself per second (no good), before the fix.
Overloading the server, for a call that doesn't need to be made.

Change `$this->pluginPath` to `$this->pluginPathFull`, so it's the relative directory path & not the external "http://example.com" path.

This affects the construct on `classes/nbpRender.php` when the `$this->tA['loader_path']` variable is set, when it does:

```
$imagesize = getimagesize($this->tA['loader_path']);
```

This causes `getimagesize()` to pull from the http:// url from the site itself, to get the image sizes, instead of it's relative path.
